### PR TITLE
feat: add admin guard

### DIFF
--- a/controllers/comment.js
+++ b/controllers/comment.js
@@ -55,10 +55,7 @@ const updateComment = async (req, res) => {
   const { text, mentionUserId } = req.body;
   try {
     const comment = Comment.findById(id);
-    await comment.updateOne(
-      { $set: { text, mentionUserId } },
-      { runValidator: true, new: true }
-    );
+    await comment.updateOne({ $set: { text, mentionUserId } }, { runValidator: true, new: true });
     return res.status(StatusCodes.OK).json('updated');
   } catch (err) {
     return res.status(StatusCodes.err).json(err);

--- a/controllers/user.js
+++ b/controllers/user.js
@@ -2,9 +2,8 @@ const { StatusCodes } = require('http-status-codes');
 const mongoose = require('mongoose');
 const User = require('../models/User');
 
-
 /**
- * @swagger 
+ * @swagger
  * components:
  *   schemas:
  *     User:
@@ -40,17 +39,17 @@ const User = require('../models/User');
  *           description: role of the user
  *         follower:
  *           type: array
- *           items: 
+ *           items:
  *             type: string
  *           description: follower of the user
  *         following:
  *           type: array
- *           items: 
+ *           items:
  *             type: string
  *           description: the following user of the user
  *         followingPost:
  *           type: array
- *           items: 
+ *           items:
  *             type: string
  *           description: followingPost of the user
  *       example:
@@ -69,7 +68,7 @@ const User = require('../models/User');
  * paths:
  *   /users/{id}:
  *     get:
- *       tags: 
+ *       tags:
  *         - user
  *       summary: Find user by id
  *       description: Return a single user
@@ -77,8 +76,8 @@ const User = require('../models/User');
  *       parameters:
  *         - name: id
  *           in: path
- *           description: ID of user to return 
- *           schema: 
+ *           description: ID of user to return
+ *           schema:
  *             type: string
  *       responses:
  *         '200':
@@ -91,9 +90,9 @@ const User = require('../models/User');
  *           description: User not found
  *   /users:
  *     post:
- *       tags: 
+ *       tags:
  *         - user
- *       summary: Add a new user 
+ *       summary: Add a new user
  *       description: Return created user
  *       operationId: createUser
  *       requestBody:

--- a/middleware/adminGuard.js
+++ b/middleware/adminGuard.js
@@ -1,0 +1,9 @@
+const User = require('../models/User');
+
+const adminGuard = async (req, res, next) => {
+  const user = await User.findById(req.userId).exec();
+  if (user.role !== 'admin') return res.sendStatus(403);
+  return next();
+};
+
+module.exports = adminGuard;

--- a/routes/comment.js
+++ b/routes/comment.js
@@ -1,5 +1,7 @@
 const { Router } = require('express');
 const auth = require('../middleware/auth');
+const adminGuard = require('../middleware/adminGuard');
+
 const {
   createComment,
   getAllComments,
@@ -20,6 +22,7 @@ commentRouter.use(auth);
 commentRouter.post('/', createComment);
 commentRouter.put('/:id', updateComment);
 // Wd don't delete comment but update "visible" value to false and then the comment won't show anymore.
-commentRouter.put('/delete/:id', deleteCommentById);
+// only admin can delete a comment
+commentRouter.put('/delete/:id', adminGuard, deleteCommentById);
 
 module.exports = commentRouter;

--- a/utils/swagger.js
+++ b/utils/swagger.js
@@ -10,8 +10,8 @@ module.exports = swaggerJsDoc({
     },
     servers: [
       {
-        url: "http://localhost:3000/v1",
-        description: "Local Server",
+        url: 'http://localhost:3000/v1',
+        description: 'Local Server',
       },
     ],
   },


### PR DESCRIPTION
add admin guard middleware. some actions could only be performed by admin. currently using this middleware on the delete comment endpoint.

![Snipaste_2022-10-01_21-55-53](https://user-images.githubusercontent.com/95953466/193408977-1acd4dc0-ec62-4211-b71d-1cab46ae5f99.jpg)
